### PR TITLE
Bugfix/exclude for build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,11 @@
 
 # Only include the addons folder when downloading from the Asset Library.
 /**                   export-ignore
+/addons               !export-ignore
 /addons/**            !export-ignore
+/example              !export-ignore
 /example/**           !export-ignore
+/example_battle       !export-ignore
 /example_battle/**    !export-ignore
+/example_solitaire    !export-ignore
 /example_solitaire/** !export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,8 @@
 * text=auto eol=lf
 
 # Only include the addons folder when downloading from the Asset Library.
-/** export-ignore
+/**                export-ignore
+/addons            !export-ignore
+/example           !export-ignore
+/example_battle    !export-ignore
+/example_solitaire !export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,8 @@
 * text=auto eol=lf
 
 # Only include the addons folder when downloading from the Asset Library.
-/**                export-ignore
-/addons            !export-ignore
-/example           !export-ignore
-/example_battle    !export-ignore
-/example_solitaire !export-ignore
+/**                   export-ignore
+/addons/**            !export-ignore
+/example/**           !export-ignore
+/example_battle/**    !export-ignore
+/example_solitaire/** !export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/** export-ignore


### PR DESCRIPTION
this excludes everything from the git archive that is unnecessary when importing into godot.

For example, before it would import things like the godot project file, readme, icon in the root directory.  Then godot would show that these files conflict when importing Card3D via the asset library.  `.gdignore` wont work for these files since that can only exclude sub directories. Excluding them from the git archive will stop these files from conflicting when importing.