### PR TITLE
Rotate back mesh to be right side up.

### DIFF
--- a/addons/card_3d/scenes/card_3d.tscn
+++ b/addons/card_3d/scenes/card_3d.tscn
@@ -22,7 +22,7 @@ script = ExtResource("1_ll0aq")
 [node name="CardMesh" type="Node3D" parent="."]
 
 [node name="CardBackMesh" type="MeshInstance3D" parent="CardMesh"]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0)
+transform = Transform3D(-1, -8.74228e-08, -4.37114e-08, 4.37114e-08, 1.91069e-15, -1, 8.74228e-08, -1, 1.91069e-15, 0, 0, 0)
 mesh = SubResource("PlaneMesh_a5dw2")
 skeleton = NodePath("../..")
 surface_material_override/0 = SubResource("StandardMaterial3D_k64yj")


### PR DESCRIPTION
Although its not vissible in the default texture due to simitry, the back mesh for the card is actually rotated upside down. This rotates it to be the correct orientation.