### PR TITLE
 Allow adding and removing card collections  to `DragController` after it is ready.

### DIFF
--- a/addons/card_3d/scripts/drag_controller.gd
+++ b/addons/card_3d/scripts/drag_controller.gd
@@ -40,13 +40,23 @@ var _card_collections: Array[CardCollection3D] = []
 func _ready():
 	var window = get_window()
 	_camera = window.get_camera_3d()
-
+	
 	for child in get_children():
 		if child is CardCollection3D:
-			_card_collections.append(child)
-			child.card_selected.connect(_on_collection_card_selected.bind(child))
-			child.mouse_enter_drop_zone.connect(_on_collection_mouse_enter_drop_zone.bind(child))
-			child.mouse_exit_drop_zone.connect(_on_collection_mouse_exit_drop_zone.bind(child))
+			add_card_collection(child)
+
+func add_card_collection(card_collection: CardCollection3D) -> void:
+	_card_collections.append(card_collection)
+	card_collection.card_selected.connect(_on_collection_card_selected.bind(card_collection))
+	card_collection.mouse_enter_drop_zone.connect(_on_collection_mouse_enter_drop_zone.bind(card_collection))
+	card_collection.mouse_exit_drop_zone.connect(_on_collection_mouse_exit_drop_zone.bind(card_collection))
+
+func remove_card_collection(card_collection: CardCollection3D) -> void:
+	if _card_collections.has(card_collection):
+		_card_collections.erase(card_collection)
+		card_collection.card_selected.disconnect(_on_collection_card_selected.bind(card_collection))
+		card_collection.mouse_enter_drop_zone.disconnect(_on_collection_mouse_enter_drop_zone.bind(card_collection))
+		card_collection.mouse_exit_drop_zone.disconnect(_on_collection_mouse_exit_drop_zone.bind(card_collection))
 
 
 func _input(event):

--- a/addons/card_3d/scripts/drag_controller.gd
+++ b/addons/card_3d/scripts/drag_controller.gd
@@ -40,7 +40,7 @@ var _card_collections: Array[CardCollection3D] = []
 func _ready():
 	var window = get_window()
 	_camera = window.get_camera_3d()
-	
+
 	for child in get_children():
 		if child is CardCollection3D:
 			add_card_collection(child)


### PR DESCRIPTION
Hello again,

This PR covers a small change I made in the `DragController` class to make it more flexible for different applications. Let me first explain some of the current limitations I am bumping into with my game, which some other developers might share in the future:

## Limitations 
The project I am working on features online functionalities, and because of that, not all the `CardCollection3D` instances on my game can be a direct child of the `DragController`. Another issue is that not all of the collections are "spawned" at the same time (e.g. The deck is loaded once the game is started, but each player's hand is loaded once they join the game)


## Proposed solution
Expose 2 new methods that allow to add or remove a `CardCollection3D`  to/from the `DragController` at any time. This change should not affect the current functionality, but would allow to get over the limitations described above.