### PR TITLE
update linter rules

### DIFF
--- a/.gdlintrc
+++ b/.gdlintrc
@@ -18,7 +18,6 @@ class-name: ([A-Z][a-z0-9]*)+
 class-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
 comparison-with-itself: null
 constant-name: _?[A-Z][A-Z0-9]*(_[A-Z0-9]+)*
-disable: []
 duplicated-load: null
 enum-element-name: '[A-Z][A-Z0-9]*(_[A-Z0-9]+)*'
 enum-name: ([A-Z][a-z0-9]*)+
@@ -26,21 +25,24 @@ excluded_directories: !!set
   .git: null
 expression-not-assigned: null
 function-argument-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
-function-arguments-number: 10
 function-name: (_on_([A-Z][a-z0-9]*)+(_[a-z0-9]+)*|_?[a-z][a-z0-9]*(_[a-z0-9]+)*)
 function-preload-variable-name: ([A-Z][a-z0-9]*)+
 function-variable-name: '[a-z][a-z0-9]*(_[a-z0-9]+)*'
 load-constant-name: (([A-Z][a-z0-9]*)+|_?[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)
 loop-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
-max-file-lines: 1000
-max-line-length: 200
-max-public-methods: 20
 max-returns: 6
 mixed-tabs-and-spaces: null
 signal-name: '[a-z][a-z0-9]*(_[a-z0-9]+)*'
 sub-class-name: _?([A-Z][a-z0-9]*)+
 tab-characters: 1
-trailing-whitespace: null
 unnecessary-pass: null
 unused-argument: null
-disable: [no-else-return, no-elif-return]
+disable: [
+  no-else-return,
+  no-elif-return,
+  trailing-whitespace,
+  function-arguments-number,
+  max-line-length,
+  max-file-lines,
+  max-public-methods
+]

--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -11,20 +11,6 @@ env:
   PROJECT_PATH: .
 
 jobs:
-  validate:
-    name: Quick Validation
-    runs-on: ubuntu-22.04
-    container:
-      image: barichello/godot-ci:4.4
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Validate Project
-        run: |
-          godot --headless --quit --editor
-          echo "✅ Project loads successfully"
-  
   quality:
     name: GDScript Quality Check
     runs-on: ubuntu-22.04
@@ -45,10 +31,11 @@ jobs:
         run: |
           echo "=== Linting all GDScript files ==="
           find . -name "*.gd" -type f | xargs gdlint
+          echo "✅ GDScript linting completed successfully"
 
   export-web:
     name: Web Export
-    needs: validate
+    needs: quality
     runs-on: ubuntu-22.04  # Use 22.04 with godot 4
     container:
       image: barichello/godot-ci:4.4


### PR DESCRIPTION
Didn't want to punish any code that the Godot default editor creates (like indentation in blank lines within a function)

I updated the rules to be more lenient and really just enforce these items in the godot style guide

https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#code-order

https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#naming-conventions