### PR TITLE
example_battle text layering issue, moved to SubViewport

### DIFF
--- a/addons/card_3d/scripts/card_collection/card_collection_3d.gd
+++ b/addons/card_3d/scripts/card_collection/card_collection_3d.gd
@@ -51,6 +51,7 @@ var is_dragging_card: bool = false
 
 var hover_disabled: bool = false # disable card hover animation (useful when dragging other cards around)
 var _hovered_card: Card3D # card currently hovered
+var _pressed_card: Card3D # card that received the last mouse down
 var _preview_drop_index: int = -1
 
 @onready var dropzone_collision: CollisionShape3D = $DropZone/CollisionShape3D
@@ -224,11 +225,14 @@ func _on_card_exit(card: Card3D):
 func _on_card_pressed(card: Card3D):
 	if can_select_card(card):
 		is_dragging_card = false
+		_pressed_card = card
 		card_selected.emit(card)
 
 
 func _on_card_deselected(card: Card3D):
-	if !is_dragging_card:
+	var was_pressed = _pressed_card == card
+	_pressed_card = null
+	if !is_dragging_card and was_pressed:
 		card_clicked.emit(card)
 	is_dragging_card = false
 	card_deselected.emit(card)

--- a/example_battle/scenes/battle_card_3d.tscn
+++ b/example_battle/scenes/battle_card_3d.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://4dl436anjvr6"]
+[gd_scene load_steps=4 format=3 uid="uid://4dl436anjvr6"]
 
 [ext_resource type="PackedScene" uid="uid://dxpc2iac0hjpw" path="res://addons/card_3d/scenes/card_3d.tscn" id="1_xagun"]
 [ext_resource type="Script" uid="uid://byfh4iocnlp5n" path="res://example_battle/scripts/battle_card_3d.gd" id="2_icem3"]
+[ext_resource type="PackedScene" uid="uid://b7y2p2k5cb3vx" path="res://example_battle/scenes/front_of_card_2d.tscn" id="4_front_of_card"]
 
 [node name="BattleCard3D" instance=ExtResource("1_xagun")]
 script = ExtResource("2_icem3")
@@ -10,9 +11,8 @@ front_material_path = ""
 damage = 0
 health = 0
 
-[node name="CardText" type="Label3D" parent="CardMesh" index="2"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.875, 0.001)
-modulate = Color(0, 0, 0, 1)
-font_size = 60
-autowrap_mode = 3
-width = 400.0
+[node name="FrontTextureViewport" type="SubViewport" parent="." index="2"]
+disable_3d = true
+size = Vector2i(500, 700)
+
+[node name="FrontTextureRoot" parent="FrontTextureViewport" index="0" instance=ExtResource("4_front_of_card")]

--- a/example_battle/scenes/front_of_card_2d.tscn
+++ b/example_battle/scenes/front_of_card_2d.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=0 format=3 uid="uid://b7y2p2k5cb3vx"]
+
+[node name="FrontTextureRoot" type="Control"]
+layout_mode = 0
+size = Vector2(500, 700)
+custom_minimum_size = Vector2(500, 700)
+
+[node name="FrontTextureBackground" type="TextureRect" parent="."]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="FrontArtGuide" type="ReferenceRect" parent="."]
+editor_only = true
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = 30.0
+offset_top = 30.0
+offset_right = -30.0
+offset_bottom = -10.0
+border_color = Color(0.2, 0.8, 0.5, 0.8)
+border_width = 2.0
+
+[node name="FrontTextGuide" type="ReferenceRect" parent="."]
+editor_only = true
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 30.0
+offset_top = 20.0
+offset_right = -30.0
+offset_bottom = -30.0
+border_color = Color(0.95, 0.7, 0.2, 0.8)
+border_width = 2.0
+
+[node name="FrontTextureLabel" type="Label" parent="."]
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 30.0
+offset_top = 20.0
+offset_right = -30.0
+offset_bottom = -30.0
+theme_override_font_sizes/font_size = 48
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3

--- a/example_battle/scenes/front_of_card_2d.tscn
+++ b/example_battle/scenes/front_of_card_2d.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=0 format=3 uid="uid://b7y2p2k5cb3vx"]
+[gd_scene format=3 uid="uid://cjunspcvj8d8a"]
 
 [node name="FrontTextureRoot" type="Control"]
-layout_mode = 0
-size = Vector2(500, 700)
 custom_minimum_size = Vector2(500, 700)
+layout_mode = 3
+anchors_preset = 0
+offset_right = 500.0
+offset_bottom = 700.0
 
 [node name="FrontTextureBackground" type="TextureRect" parent="."]
 layout_mode = 0
@@ -13,7 +15,6 @@ grow_horizontal = 2
 grow_vertical = 2
 
 [node name="FrontArtGuide" type="ReferenceRect" parent="."]
-editor_only = true
 layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 0.5
@@ -25,7 +26,6 @@ border_color = Color(0.2, 0.8, 0.5, 0.8)
 border_width = 2.0
 
 [node name="FrontTextGuide" type="ReferenceRect" parent="."]
-editor_only = true
 layout_mode = 0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -46,6 +46,9 @@ offset_left = 30.0
 offset_top = 20.0
 offset_right = -30.0
 offset_bottom = -30.0
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 4
+theme_override_constants/shadow_offset_y = 4
 theme_override_font_sizes/font_size = 48
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/example_battle/scripts/battle_card_3d.gd
+++ b/example_battle/scripts/battle_card_3d.gd
@@ -2,27 +2,73 @@ class_name BattleCard3D
 extends Card3D
 
 @export var id: String = ""
-@export var front_material_path: String:
-	set(path):
-		if path:
-			var material = load(path)
 
-			if material:
-				$CardMesh/CardFrontMesh.set_surface_override_material(0, material)
+@export var front_material_path: String = "":
+	set(value):
+		front_material_path = value
+		if is_inside_tree():
+			_apply_front()
 
 @export var damage: int = 0:
-	set(d):
-		damage = d
-		if damage > 0 and has_node("CardMesh/CardText"):
-			$CardMesh/CardText.text = "Deal " + str(damage) + " damage"
+	set(value):
+		damage = value
+		if is_inside_tree():
+			_apply_overlay()
 
 @export var health: int = 0:
-	set(h):
-		health = h
-		if has_node("CardMesh/CardText"):
-			$CardMesh/CardText.font_size = 100
-			$CardMesh/CardText.modulate = Color(1,0,0)
-			$CardMesh/CardText.text = str(health)
+	set(value):
+		health = value
+		if is_inside_tree():
+			_apply_overlay()
+
+@onready var front_viewport: SubViewport = $FrontTextureViewport
+@onready var front_root: Control = $FrontTextureViewport/FrontTextureRoot
+@onready var front_background: TextureRect = $FrontTextureViewport/FrontTextureRoot/FrontTextureBackground
+@onready var front_label: Label = $FrontTextureViewport/FrontTextureRoot/FrontTextureLabel
+var _front_material_override := StandardMaterial3D.new()
+
+
+func _ready() -> void:
+	front_viewport.disable_3d = true
+	front_viewport.transparent_bg = true
+	front_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+	front_background.stretch_mode = TextureRect.STRETCH_SCALE
+	_front_material_override.albedo_texture = front_viewport.get_texture()
+	$CardMesh/CardFrontMesh.set_surface_override_material(0, _front_material_override)
+	_apply_front()
+	_apply_overlay()
+
+
+func _apply_front() -> void:
+	if front_material_path == "":
+		return
+	var material = load(front_material_path)
+	if material == null:
+		return
+	if material is StandardMaterial3D and material.albedo_texture != null:
+		var texture = material.albedo_texture
+		var size: Vector2i = texture.get_size()
+		front_background.texture = texture
+		front_viewport.size = Vector2i(int(size.x), int(size.y))
+		front_root.size = size
+		front_root.custom_minimum_size = size
+		front_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+		return
+	$CardMesh/CardFrontMesh.set_surface_override_material(0, material)
+
+
+func _apply_overlay() -> void:
+	if health > 0:
+		front_label.text = str(health)
+		front_label.modulate = Color(1, 0, 0)
+		front_label.add_theme_font_size_override("font_size", 100)
+	elif damage > 0:
+		front_label.text = "Deal %d damage" % damage
+		front_label.modulate = Color(0, 0, 0)
+		front_label.add_theme_font_size_override("font_size", 60)
+	else:
+		front_label.text = ""
+	front_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
 
 
 func _to_string():

--- a/example_battle/scripts/battle_card_3d.gd
+++ b/example_battle/scripts/battle_card_3d.gd
@@ -63,7 +63,7 @@ func _apply_overlay() -> void:
 		front_label.modulate = Color(1, 0, 0)
 		front_label.add_theme_font_size_override("font_size", 100)
 	elif damage > 0:
-		front_label.text = "Deal %d damage" % damage
+		front_label.text = "Deal %d\ndamage" % damage
 		front_label.modulate = Color(0, 0, 0)
 		front_label.add_theme_font_size_override("font_size", 60)
 	else:

--- a/example_battle/scripts/battle_card_3d.gd
+++ b/example_battle/scripts/battle_card_3d.gd
@@ -21,11 +21,11 @@ extends Card3D
 		if is_inside_tree():
 			_apply_overlay()
 
+var _front_material_override := StandardMaterial3D.new()
 @onready var front_viewport: SubViewport = $FrontTextureViewport
 @onready var front_root: Control = $FrontTextureViewport/FrontTextureRoot
 @onready var front_background: TextureRect = $FrontTextureViewport/FrontTextureRoot/FrontTextureBackground
 @onready var front_label: Label = $FrontTextureViewport/FrontTextureRoot/FrontTextureLabel
-var _front_material_override := StandardMaterial3D.new()
 
 
 func _ready() -> void:


### PR DESCRIPTION
If you double the number of cards in the example battle, it's easy to see the issue.

The text on each card is on top of the CardFrontMesh for all cards until you start dragging one, then the one you are dragging does draw in front of others... but the ones behind still have all the text meshes coming out on top of the texture meshes.

The solution was to either make card layout put all the cards on separate z offsets perfectly, or move the text into a SubViewport and render that on the CardFrontMesh.

I went with the latter, and tried to keep it relatively short.
Before
<img width="1035" height="781" alt="image" src="https://github.com/user-attachments/assets/9fc00c34-c396-48b9-9f8c-09903de1e207" />
After
<img width="1373" height="869" alt="image" src="https://github.com/user-attachments/assets/43bfb055-cc8c-42fb-a818-398c7123a2f5" />

If the shadow effect on the text is important you can add it with a Theme override like so:

<img width="541" height="405" alt="image" src="https://github.com/user-attachments/assets/5bec1ebe-39ff-4bb0-ad8e-e27078bb4d9b" />

Then you get something like this...
<img width="1220" height="857" alt="image" src="https://github.com/user-attachments/assets/14c9f285-b939-425e-bde8-8e426b3136af" />